### PR TITLE
Add net.Dialer override to dnsr, configurable through options

### DIFF
--- a/resolver_test.go
+++ b/resolver_test.go
@@ -41,6 +41,12 @@ func TestDeadlineExceeded(t *testing.T) {
 	st.Expect(t, err, context.DeadlineExceeded)
 }
 
+func TestFluentConstructorDeadlineExceeded(t *testing.T) {
+	r := NewResolver(0, WithTimeout(0))
+	_, err := r.ResolveErr("1.com", "")
+	st.Expect(t, err, context.DeadlineExceeded)
+}
+
 func TestResolveCtx(t *testing.T) {
 	r := New(0)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)


### PR DESCRIPTION
The NewXYZ pattern is limiting in the maximum number of parameters
that could be encoded in the method.